### PR TITLE
Add maximal heap size to compile tasks

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -251,6 +251,14 @@ gradle.projectsEvaluated {
     task testCoverage(type: Test) {
         classpath = getScoverageClasspath(project, projectsWithCoverage)
     }
+
+    tasks.withType(ScalaCompile) {
+        scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+        configure(scalaCompileOptions.forkOptions) {
+            memoryMaximumSize = '1g'
+        }
+    }
+
     tasks.withType(Test) {
         systemProperties(System.getProperties())
         systemProperty("whisk.server.jar", getStandaloneJarFilePath())

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -253,7 +253,6 @@ gradle.projectsEvaluated {
     }
 
     tasks.withType(ScalaCompile) {
-        scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
         configure(scalaCompileOptions.forkOptions) {
             memoryMaximumSize = '1g'
         }


### PR DESCRIPTION
Upstream projects to Openwhisk (e.g. IBM Cloud Functions) need an enhanced heap limit to compile the tests consistently after pureconfig is upgraded.
This behavior is unfortunately not reproducible in the normal Openwhisk Travis build 
but with high consistency in our upstream builds (rate > 95%).

